### PR TITLE
Better shouting detection

### DIFF
--- a/lib/despamilator/filter/shouting.rb
+++ b/lib/despamilator/filter/shouting.rb
@@ -18,7 +18,7 @@ module DespamilatorFilter
 
       return if text.length < 20
 
-      uppercased = text.scan(/[A-Z]/).length
+      uppercased = text.scan(/[A-Z][A-Z]+/).join.length
       lowercased = text.scan(/[a-z]/).length
 
       if uppercased > 0

--- a/spec/filters/shouting_spec.rb
+++ b/spec/filters/shouting_spec.rb
@@ -28,6 +28,7 @@ describe DespamilatorFilter::Shouting do
 
   [
           ['this is a lowercased string', 0],
+          ['This is a String with Capital Letters', 0],
           ['this lil string is 50 PERCENT SHOUTING', 0.25],
           ['THIS LIL STRING IS 100 PERCENT SHOUTING', 0.5]
   ].each do |string, expected_score|


### PR DESCRIPTION
I noticed that the shouting filter just looks for any uppercase letter, so it matches on capitalized words in perfectly normal content. This patch makes sure it looks for combinations of 2 or more caps and then uses those toward the score. I added a test and made sure everything still passes.
