### PR TITLE
handling exception which despamilator generates

### DIFF
--- a/lib/despamilator/subject/text.rb
+++ b/lib/despamilator/subject/text.rb
@@ -5,7 +5,7 @@ class Despamilator
     class Text < String
 
       def initialize text
-        super text
+        super text if text
         freeze
       end
 


### PR DESCRIPTION
If any of attribute is nil then despamilator return this exception. This condition stops exception.
Despamilator return this exception: can't convert nil into String
In my opinions gem shouldn't do anything when specified attributes are nil.